### PR TITLE
Feat/session readonly

### DIFF
--- a/source/sharedb-ace-binding.js
+++ b/source/sharedb-ace-binding.js
@@ -52,6 +52,14 @@ class SharedbAceBinding {
     this.plugins = options.plugins || [];
     this.onError = options.onError;
     this.logger = new Logdown('shareace');
+    // this.clientId = options.clientId; //readOnly setting
+    if (options.doc.data.options.readOnly) {
+      if (options.clientId == options.doc.data.ownerId) {
+        this.readOnly = false;
+      } else {
+        this.readOnly = true;
+      }
+    }
 
     // Initialize plugins
     this.plugins.forEach((plugin) => {
@@ -79,6 +87,9 @@ class SharedbAceBinding {
   setInitialValue() {
     this.suppress = true;
     this.session.setValue(traverse(this.doc.data, this.path));
+    this.editor.setOptions({
+      readOnly: this.readOnly //this.doc.data.options.readOnly;
+    });
     this.suppress = false;
   }
 

--- a/source/sharedb-ace-binding.js
+++ b/source/sharedb-ace-binding.js
@@ -29,6 +29,7 @@ class SharedbAceBinding {
    * sharedb-ace plugins
    * @param {string[]} options.path - A lens, describing the nesting
    * to the JSON document. It should point to a string.
+   * @param {boolean} options.readOnly - whether the session is read-only
    * @param {Object[]} options.plugins - array of sharedb-ace plugins
    * @param {?function} options.onError - a callback on error
    * @example
@@ -52,19 +53,16 @@ class SharedbAceBinding {
     this.plugins = options.plugins || [];
     this.onError = options.onError;
     this.logger = new Logdown('shareace');
-    // this.clientId = options.clientId; //readOnly setting
-    if (options.doc.data.options.readOnly) {
-      if (options.clientId == options.doc.data.ownerId) {
-        this.readOnly = false;
-      } else {
-        this.readOnly = true;
-      }
-    }
 
     // Initialize plugins
     this.plugins.forEach((plugin) => {
       plugin(this.pluginWS, this.editor);
     });
+
+    // Sets the editor to read-only if necessary
+    this.editor.setOptions({
+      readOnly: options.readOnly
+    })
 
     // When ops are applied to sharedb, ace emits edit events.
     // This events need to be suppressed to prevent infinite looping
@@ -87,9 +85,6 @@ class SharedbAceBinding {
   setInitialValue() {
     this.suppress = true;
     this.session.setValue(traverse(this.doc.data, this.path));
-    this.editor.setOptions({
-      readOnly: this.readOnly //this.doc.data.options.readOnly;
-    });
     this.suppress = false;
   }
 

--- a/source/sharedb-ace.js
+++ b/source/sharedb-ace.js
@@ -32,12 +32,12 @@ class SharedbAce extends EventEmitter {
    * @param {string} options.WsUrl - Websocket URL for ShareDB
    * @param {string} options.pluginWsUrl - Websocket URL for extra plugins
    * (different port from options.WsUrl)
-   * @param {boolean} options.clientId - newly added client id for ShareAce instance
+   * @param {boolean} options.readOnly - whether the session is read-only
    */
   constructor(id, options) {
     super();
     this.id = id;
-    this.clientId = options.clientId;
+    this.readOnly = options.readOnly
     if (options.pluginWsUrl !== null) {
       this.pluginWS = new WebSocket(options.pluginWsUrl);
     }
@@ -73,8 +73,6 @@ class SharedbAce extends EventEmitter {
     doc.subscribe(docSubscribed);
     this.doc = doc;
     this.connections = {};
-    console.log(doc);
-    console.log(doc.data);
   }
 
   /**
@@ -95,8 +93,7 @@ class SharedbAce extends EventEmitter {
       doc: this.doc,
       path: sharePath,
       pluginWS: this.pluginWS,
-      id: this.id,
-      clientId: this.clientId,
+      readOnly: this.readOnly,
       plugins,
       onError: (error) => this.emit('error', path, error)
     });

--- a/source/sharedb-ace.js
+++ b/source/sharedb-ace.js
@@ -32,10 +32,12 @@ class SharedbAce extends EventEmitter {
    * @param {string} options.WsUrl - Websocket URL for ShareDB
    * @param {string} options.pluginWsUrl - Websocket URL for extra plugins
    * (different port from options.WsUrl)
+   * @param {boolean} options.clientId - newly added client id for ShareAce instance
    */
   constructor(id, options) {
     super();
     this.id = id;
+    this.clientId = options.clientId;
     if (options.pluginWsUrl !== null) {
       this.pluginWS = new WebSocket(options.pluginWsUrl);
     }
@@ -52,7 +54,6 @@ class SharedbAce extends EventEmitter {
     }
     const namespace = options.namespace;
     const doc = connection.get(namespace, id);
-
     // Fetches once from the server, and fires events
     // on subsequent document changes
     const docSubscribed = (err) => {
@@ -68,11 +69,12 @@ class SharedbAce extends EventEmitter {
 
       this.emit('ready');
     };
-
+    
     doc.subscribe(docSubscribed);
-
     this.doc = doc;
     this.connections = {};
+    console.log(doc);
+    console.log(doc.data);
   }
 
   /**
@@ -94,6 +96,7 @@ class SharedbAce extends EventEmitter {
       path: sharePath,
       pluginWS: this.pluginWS,
       id: this.id,
+      clientId: this.clientId,
       plugins,
       onError: (error) => this.emit('error', path, error)
     });

--- a/source/sharedb-ace.js
+++ b/source/sharedb-ace.js
@@ -93,6 +93,7 @@ class SharedbAce extends EventEmitter {
       doc: this.doc,
       path: sharePath,
       pluginWS: this.pluginWS,
+      id: this.id,
       readOnly: this.readOnly,
       plugins,
       onError: (error) => this.emit('error', path, error)


### PR DESCRIPTION
Description: 
Adds an option to invite other users to a session as viewers (read-only mode) or editors.

Changes:
Added new read only option field when creating a ShareAce instance
Sets editor binding’s read only mode to true/false depending on arguments passed into read only field
