### PR TITLE
Fix commonjs and ESM confusion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,21 +1,25 @@
 {
   "name": "@sourceacademy/sharedb-ace",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "ShareDB integration with Ace Editor",
   "main": "dist/sharedb-ace.js",
   "module": "dist/sharedb-ace.mjs",
   "types": "dist/sharedb-ace.d.ts",
+  "type": "commonjs",
   "exports": {
     ".": {
-      "import": "./dist/sharedb-ace.js",
+      "require": "./dist/sharedb-ace.js",
+      "import": "./dist/sharedb-ace.mjs",
       "types": "./dist/sharedb-ace.d.ts"
     },
     "./binding": {
-      "import": "./dist/sharedb-ace-binding.js",
+      "require": "./dist/sharedb-ace-binding.js",
+      "import": "./dist/sharedb-ace-binding.mjs",
       "types": "./dist/sharedb-ace-binding.d.ts"
     },
     "./types": {
-      "import": "./dist/types.js",
+      "require": "./dist/types.js",
+      "import": "./dist/types.mjs",
       "types": "./dist/types.d.ts"
     }
   },


### PR DESCRIPTION
Apologies, but hopefully this is the final hurdle to get the sessions PR mixed. This is a summary of what I've done:

- Specified that this module is a `commonjs` module
  - As a result, tsup will output js, mjs and d.ts file extensions the `tsup.config.ts` file specifies outputs of cjs, esm and dts files
- Specified the correct files to use when using import/require respectively
  - The default js files are commonjs format, as our package.json specifies that this is a commonjs package
  - mjs files will be used when using import, which requires ESM packages

Lastly, I've verified that this all works when running test, format or eslint scripts and when running the dev environment, all with no issues.

_Note_: Requires bumping of the npm package, again